### PR TITLE
Feature/save python image size

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-slim
 
 WORKDIR /usr/src/duo34/backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,17 +14,6 @@ services:
       FLASK_APP: run.py
       FLASK_ENV: development
     command: sh -c  "sh procedure.sh && flask run -h 0.0.0.0 --port 5000"
-
-  db:
-    image: nouchka/sqlite3:latest
-    stdin_open: true
-    tty: true
-    volumes:
-      - "./backend/src/db/:/usr/src/duo34/backend/src/db/"
-    ports:
-      - "3306:3306"
-    depends_on: 
-      - backend
       
   frontend:
     build: 


### PR DESCRIPTION
python3.7イメージ909MBからpython3.7-slimイメージ154MBまで小さくなった
DBのイメージを使っていなかったので、削除（動作確認済み）